### PR TITLE
feat: service info api protection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,9 @@ SERVICE_INFO_SECRET_KEY=""
 # Optional:Posthog(Analytics tool)
 NEXT_PUBLIC_POSTHOG_KEY=""
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# Service info api endpoint secret keys
+# Optional:Protects the cron job endpoint(/api/serviceinfo)
+CRON_SECRET="very secret key"
+# Optional:Service info api key(/api/serviceinfo/[secretkey])
+NEXT_SERVICE_INFO_SECRET_KEY="very secret key"

--- a/src/app/api/serviceinfo/[secretkey]/route.ts
+++ b/src/app/api/serviceinfo/[secretkey]/route.ts
@@ -1,0 +1,12 @@
+import { env } from "process";
+import { updateServiceInfo } from "../route";
+
+async function handler({ params }: { params: Promise<{ secretkey: string }> }) {
+  const { secretkey } = await params;
+  if (secretkey !== env.NEXT_SERVICE_INFO_SECRET_KEY) {
+    return new Response("Invalid secret key", { status: 401 });
+  }
+  return updateServiceInfo();
+}
+
+export { handler as GET, handler as POST };

--- a/src/app/api/serviceinfo/[secretkey]/route.ts
+++ b/src/app/api/serviceinfo/[secretkey]/route.ts
@@ -1,7 +1,11 @@
+import { type NextRequest } from "next/server";
 import { env } from "process";
 import { updateServiceInfo } from "../route";
 
-async function handler({ params }: { params: Promise<{ secretkey: string }> }) {
+async function handler(
+  _: NextRequest,
+  { params }: { params: Promise<{ secretkey: string }> },
+) {
   const { secretkey } = await params;
   if (secretkey !== env.NEXT_SERVICE_INFO_SECRET_KEY) {
     return new Response("Invalid secret key", { status: 401 });

--- a/src/app/api/serviceinfo/route.ts
+++ b/src/app/api/serviceinfo/route.ts
@@ -16,7 +16,7 @@ const SERVICE_INFO_SCHEMA = z.object({
   ),
 });
 
-export async function GET() {
+export async function updateServiceInfo() {
   if (env.SERVICE_INFO_LINK === undefined) {
     return new Response("Service info link not set", { status: 500 });
   } else if (env.SERVICE_INFO_SECRET_KEY === undefined) {
@@ -64,4 +64,20 @@ export async function GET() {
       status: 500,
     });
   }
+}
+
+/**
+ * This function is for vercel cron job. It is also protected by a secret key.
+ * See https://vercel.com/docs/cron-jobs/manage-cron-jobs#securing-cron-jobs
+ * @param request
+ * @returns
+ */
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response("Unauthorized", {
+      status: 401,
+    });
+  }
+  return updateServiceInfo();
 }


### PR DESCRIPTION
# Feature
1. Add additional serviceinfo endpoint to allow api key passed in as a dynamic route.
2. Add header protection on serviceinfo endpoint with static route

# Details
1. Add additional serviceinfo endpoint to allow api key passed in as a dynamic route.
Api key can be set as environmental variable with NEXT_SERVICE_INFO_SECRET_KEY can be passed via dynamic route.
This allows for work to be triggered in `/api/serviceinfo/{{ env.NEXT_SERVICE_INFO_SECRET_KEY }}`.

2. Add header protection on serviceinfo endpoint with static route
Vercel cron jobs automatically passes in env.CRON_SECRET to all cron request when set as the environmental variable.