### PR TITLE
Add compose.yaml as supabase replacement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,17 @@
 DATABASE_URL="file:./db.sqlite"
 DIRECT_URL="file:./db.sqlite"
 
+# Optional:Docker(Postgres database)
+# NOTE: Docker will read from these to configure the postgresql database
+# DB_HOST=localhost
+# DB_PORT=5432
+# DB_USER=username
+# DB_PASSWORD=password
+# DB_NAME=postgres
+
+# DATABASE_URL="postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?pgbouncer=true"
+# DIRECT_URL="postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+
 # Required:Upstash Redis(Used for caching)
 # While this could be optional, it is highly recommended to use it for better performance and not max out db usage.
 # https://upstash.com/redis or 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,15 @@
+services:
+  db:
+    image: "postgres:14.17"
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_DB=$DB_NAME
+      - POSTGRES_USER=$DB_USER
+      - POSTGRES_PASSWORD=$DB_PASSWORD
+    volumes:
+      - ./etc/postgresql.conf:/etc/postgresql/postgresql.conf:ro
+      - database:/var/lib/postgresql/data
+
+volumes:
+  database:

--- a/etc/postgresql.conf
+++ b/etc/postgresql.conf
@@ -1,0 +1,9 @@
+listen_addresses = '*'
+port = 5432
+
+bonjour = off
+
+log_destination = 'stderr'
+log_rotation_age = 0d
+
+timezone = 'EST'


### PR DESCRIPTION
- Adds a `compose.yaml` that creates a postgres container from the variables defined in `.env`
- Modifies `.env.example` with the alternative environment variables
- Adds new file `etc/postgresql.conf` for configuring postgres container