### PR TITLE
hot-fix: change data passed in to animated lists

### DIFF
--- a/src/app/_components/animatedList.tsx
+++ b/src/app/_components/animatedList.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { AnimatePresence, motion } from "framer-motion";
-import { type ReactElement, useState } from "react";
+import React, { type ReactElement, useState } from "react";
+
+type ChildDataProp = {
+  "data-bus-id"?: string;
+};
 
 export function AnimatedDoubleList({
   children,
@@ -16,14 +20,20 @@ export function AnimatedDoubleList({
 }) {
   const [favoritedChildren, setFavoritedChildren] = useState<ReactElement[]>(
     children.filter((child) => {
-      return child.key ? favoritedBusKeys.includes(child.key) : false;
+      const busId =
+        React.isValidElement(child) &&
+        (child.props as ChildDataProp)["data-bus-id"];
+      return busId ? favoritedBusKeys.includes(busId) : false;
     }),
   );
   const [unfavoritedChildren, setUnfavoritedChildren] = useState<
     ReactElement[]
   >(
     children.filter((child) => {
-      return child.key ? !favoritedBusKeys.includes(child.key) : false;
+      const busId =
+        React.isValidElement(child) &&
+        (child.props as ChildDataProp)["data-bus-id"];
+      return busId ? !favoritedBusKeys.includes(busId) : true;
     }),
   );
 

--- a/src/app/_components/busStatus.tsx
+++ b/src/app/_components/busStatus.tsx
@@ -176,15 +176,17 @@ export async function BusList() {
       }
       locked={!user}
     >
-      {buses.map((bus) => {
-        return (
-          <div className="h-full w-full" key={bus.id}>
-            <Suspense fallback={<BusInfoSkeleton />}>
-              <BusInfo bus={bus} isFavorited={favBusesId.includes(bus.id)} />
-            </Suspense>
-          </div>
-        );
-      })}
+      {buses.map((bus) => (
+        <div
+          className="h-full w-full"
+          key={bus.id}
+          data-bus-id={bus.id.toString()}
+        >
+          <Suspense fallback={<BusInfoSkeleton />}>
+            <BusInfo bus={bus} isFavorited={favBusesId.includes(bus.id)} />
+          </Suspense>
+        </div>
+      ))}
     </AnimatedDoubleList>
   );
 }


### PR DESCRIPTION
# Changes
1. Animated double lists determines children based on id which wasn't official way of determining such features. This has been changed to passing based on data attribute

# Related Issues
None
