### PR TITLE
fix: animated list

### DIFF
--- a/src/app/_components/animatedList.tsx
+++ b/src/app/_components/animatedList.tsx
@@ -33,6 +33,7 @@ export function AnimatedDoubleList({
       const busId =
         React.isValidElement(child) &&
         (child.props as ChildDataProp)["data-bus-id"];
+      console.log(child.props);
       return busId ? !favoritedBusKeys.includes(busId) : true;
     }),
   );

--- a/src/app/_components/animatedList.tsx
+++ b/src/app/_components/animatedList.tsx
@@ -33,7 +33,6 @@ export function AnimatedDoubleList({
       const busId =
         React.isValidElement(child) &&
         (child.props as ChildDataProp)["data-bus-id"];
-      console.log(child.props);
       return busId ? !favoritedBusKeys.includes(busId) : true;
     }),
   );

--- a/src/app/_components/busStatus.tsx
+++ b/src/app/_components/busStatus.tsx
@@ -182,9 +182,7 @@ export async function BusList() {
           key={bus.id}
           data-bus-id={bus.id.toString()}
         >
-          <Suspense fallback={<BusInfoSkeleton />}>
-            <BusInfo bus={bus} isFavorited={favBusesId.includes(bus.id)} />
-          </Suspense>
+          <BusInfo bus={bus} isFavorited={favBusesId.includes(bus.id)} />
         </div>
       ))}
     </AnimatedDoubleList>


### PR DESCRIPTION
# Changes
1. Fix favoriting lists in home page

This was caused about server side rendering and client side rendering boundary crossing between the code logic for determining list positioning during client rendering. One issue that was caused by that crossing was the suspense block where the vercel hosting may have cached differently and had different ways that it passed in the data to the client.

# Related Issues
None
