### PR TITLE
fix: remove utc zone conversion during display of time

### DIFF
--- a/src/app/_components/editors/editBusRoute.tsx
+++ b/src/app/_components/editors/editBusRoute.tsx
@@ -106,10 +106,10 @@ function savedRouteToDateInput(data: {
 }): { arr: string; dep: string } {
   return {
     arr: data.arriTime
-      ? DateTime.fromJSDate(data.arriTime, { zone: "utc" }).toFormat("HH:mm")
+      ? DateTime.fromJSDate(data.arriTime).toFormat("HH:mm")
       : "",
     dep: data.deptTime
-      ? DateTime.fromJSDate(data.deptTime, { zone: "utc" }).toFormat("HH:mm")
+      ? DateTime.fromJSDate(data.deptTime).toFormat("HH:mm")
       : "",
   };
 }

--- a/src/app/_components/timeTable.tsx
+++ b/src/app/_components/timeTable.tsx
@@ -3,7 +3,7 @@
 import { TimeTableSkeleton } from "@/busPageLoaders";
 import { useBusStatus } from "@/hooks";
 import type { BusRoute } from "@/types";
-import { formatToLocalTimeString, getArriTime } from "@/util";
+import { formatToTimeString, getArriTime } from "@/util";
 import { useSearchParams } from "next/navigation";
 import { api } from "t/react";
 
@@ -67,13 +67,9 @@ export default function TimeTable({
                 <div className="mx-[6px] h-full w-2 bg-(--bus-color)" />
                 <div className="bg-item-background absolute top-1/2 left-1/2 aspect-square w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-[3px] border-slate-700 dark:border-slate-50" />
               </div>
-              <p className="w-[74px] py-2">
-                {formatToLocalTimeString(arriTime)}
-              </p>
+              <p className="w-[74px] py-2">{formatToTimeString(arriTime)}</p>
               <p className="py-2 pr-2">-</p>
-              <p className="w-[74px] py-2">
-                {formatToLocalTimeString(r.deptTime)}
-              </p>
+              <p className="w-[74px] py-2">{formatToTimeString(r.deptTime)}</p>
             </div>
           </div>
         );

--- a/src/app/_components/util.ts
+++ b/src/app/_components/util.ts
@@ -236,6 +236,6 @@ export function splitByKeywords(
   );
 }
 
-export function formatToLocalTimeString(date: Date) {
-  return DateTime.fromJSDate(date, { zone: "utc" }).toFormat("h:mm a");
+export function formatToTimeString(date: Date) {
+  return DateTime.fromJSDate(date).toFormat("h:mm a");
 }


### PR DESCRIPTION
# Changes
1. Time conversion occurs during display due to zone selected when creating Datetime object from jsdate obj.

# Related Issues
None