### PR TITLE
fix: merge service info by title instead of hash

### DIFF
--- a/src/app/_components/serviceinfo.tsx
+++ b/src/app/_components/serviceinfo.tsx
@@ -73,8 +73,8 @@ export function ServiceInfoProvider({
             </div>
           ) : (
             <div className="flex flex-col gap-2 p-3 pb-0">
-              {data.map((alert) => (
-                <div key={alert.hash} className="flex flex-col gap-2">
+              {data.map((alert, i) => (
+                <div key={i} className="flex flex-col gap-2">
                   <div className="flex flex-row items-center justify-between">
                     <p className="text-lg font-semibold">{alert.title}</p>
                     <p className="text-sm font-semibold text-gray-500">

--- a/src/server/api/routers/serviceInfo.ts
+++ b/src/server/api/routers/serviceInfo.ts
@@ -29,7 +29,7 @@ export const serviceInfoRouter = createTRPCRouter({
             createdAt: "desc",
           },
         })
-        .then((serviceInfo) => _.groupBy(serviceInfo, "hash"));
+        .then((serviceInfo) => _.groupBy(serviceInfo, "title"));
       const serviceInfos = Object.entries(savedServiceInfo).map(([_, info]) => {
         const buses = info
           .map((i) => ({ bus: i.bus, id: i.busId }))
@@ -58,7 +58,7 @@ export const serviceInfoRouter = createTRPCRouter({
   getCount: publicProcedure.query(async ({ ctx }) => {
     return ctx.db.serviceInformation
       .findMany({
-        distinct: "hash",
+        distinct: "title",
       })
       .then((l) => l.length);
   }),


### PR DESCRIPTION
# Changes
1. merge logic of service info component will only show one message due to merging with hash

> [!NOTE]
> hash is no longer unique to every service info and rather is the same for all service info for the extracted session.

# Related Issues
None
