### PR TITLE
fix: remove posthog.reset that is called in useeffect

### DIFF
--- a/src/app/_components/posthog.tsx
+++ b/src/app/_components/posthog.tsx
@@ -59,8 +59,6 @@ function PostHogUserIdentifier() {
       });
       return;
     }
-
-    posthog.reset();
   }, [isLoaded, posthog, user]);
 
   return null;


### PR DESCRIPTION
# Changes
> Describe the changes you have made to fix or add a new feature in a numbered list.

1. remove reset function from being called

# Related Issues
> Reference the issues that are related to this PR. If there isn't one, add a new discussion topic for a new feature or create an issue for bugs.
> Try to reduce the number of issues here as it would be harder for your PR to get merged.

